### PR TITLE
fix: put dropout layers in right positions for rnns

### DIFF
--- a/rul_adapt/model/rnn.py
+++ b/rul_adapt/model/rnn.py
@@ -249,7 +249,6 @@ class _Rnn(nn.Module):
                 self._rnn_func(
                     int(input_channels * unit_multiplier),  # in channels could be odd
                     num_units,
-                    dropout=self.dropout,
                     bidirectional=self.bidirectional,
                 )
             )
@@ -259,7 +258,9 @@ class _Rnn(nn.Module):
     def forward(
         self, inputs: torch.Tensor
     ) -> Tuple[torch.Tensor, Tuple[torch.Tensor, torch.Tensor]]:
-        for rnn in self._layers:
+        for i, rnn in enumerate(self._layers, start=1):
             inputs, states = rnn(inputs)
+            if i < len(self._layers):  # no dropout on last layer outputs
+                inputs = nn.functional.dropout(inputs, self.dropout)
 
         return inputs, states


### PR DESCRIPTION
The rnn classes do not permit dropout for just one layer. As the custom rnn implementation for different rnn units per layer uses 1-layer rnns under the hood, the dropout layers have to be places manually.