### PR TITLE
fix: introduce epsilon for pairwise euclidean

### DIFF
--- a/rul_adapt/loss/utils.py
+++ b/rul_adapt/loss/utils.py
@@ -25,16 +25,15 @@ def _calc_pairwise_distances(
     x: torch.Tensor, y: torch.Tensor, dist_func: Callable
 ) -> torch.Tensor:
     """Compute pairwise euclidean distances between features."""
-    num_elems = x.shape[0]
-    x = x.view(num_elems, 1, -1)
-    y = y.view(1, num_elems, -1)
+    x = x[:, None]
+    y = y[None, :]
     distances = dist_func(x, y)
 
     return distances
 
 
-def _euclidean(x, y):
-    return torch.sqrt((x - y) ** 2).sum(-1)
+def _euclidean(x: torch.Tensor, y: torch.Tensor) -> torch.Tensor:
+    return torch.sqrt((x - y) ** 2 + 1e-7).sum(-1)
 
 
 def _dot(x, y):

--- a/tests/test_loss/test_adaption.py
+++ b/tests/test_loss/test_adaption.py
@@ -14,8 +14,8 @@ def manual_seed():
 
 
 def test_mmd_same_dist():
-    source = torch.randn(1000, 1)
-    target = torch.randn(1000, 1)
+    source = torch.randn(1000, 10)
+    target = torch.randn(1000, 10)
     mmd = loss.MaximumMeanDiscrepancyLoss(num_kernels=5)
 
     mmd_loss = mmd(source, target)
@@ -24,14 +24,26 @@ def test_mmd_same_dist():
 
 
 def test_mmd_diff_dist():
-    source = torch.randn(1000, 1)
-    target = torch.randn(1000, 1)
+    source = torch.randn(100, 10)
+    target = torch.randn(100, 10)
     mmd = loss.MaximumMeanDiscrepancyLoss(num_kernels=5)
 
     mmd_loss_1 = mmd(source * 2, target)
     mmd_loss_2 = mmd((source * 2) + 1, target)
 
     assert mmd_loss_1 < mmd_loss_2
+
+
+def test_mmd_backward():
+    source = torch.randn(100, 10, requires_grad=True)
+    target = torch.randn(100, 10, requires_grad=True)
+    mmd = loss.MaximumMeanDiscrepancyLoss(num_kernels=5)
+
+    mmd_loss_1 = mmd(source * 2, target)
+    mmd_loss_1.backward()
+
+    assert not source.grad.isnan().any()
+    assert not target.grad.isnan().any()
 
 
 def test_jmmd_same_dist():
@@ -57,8 +69,8 @@ def test_jmmd_diff_dist():
 
 
 def test_dann_perfect_disc():
-    source = torch.randn(500, 1) - 50
-    target = torch.randn(500, 1) + 50
+    source = torch.randn(50, 10) - 50
+    target = torch.randn(50, 10) + 50
     dummy_disc = lambda x: torch.mean(x, dim=1, keepdim=True)
     dann = loss.DomainAdversarialLoss(dummy_disc)
 


### PR DESCRIPTION
Gradient of euclidean distance is not defined for a distance of zero. Introducing an epsilon solves the issue.