### PR TITLE
fix: hparam logging issue

### DIFF
--- a/rul_adapt/construct/adarul/config/base.yaml
+++ b/rul_adapt/construct/adarul/config/base.yaml
@@ -11,6 +11,7 @@ dm:
   batch_size: 10
 
 feature_extractor:
+  _convert_: all  # needed for tensorboard hparam dumping
   _target_: rul_adapt.model.ActivationDropoutWrapper
   wrapped:
     _target_: rul_adapt.model.LstmExtractor
@@ -20,6 +21,7 @@ feature_extractor:
   dropout: 0.5
 
 regressor:
+  _convert_: all
   _target_: rul_adapt.model.FullyConnectedHead
   input_channels: 64
   act_func_on_last_layer: False
@@ -27,6 +29,7 @@ regressor:
   dropout: 0.5
 
 domain_disc:
+  _convert_: all
   _target_: rul_adapt.model.FullyConnectedHead
   input_channels: 64
   act_func_on_last_layer: False

--- a/rul_adapt/construct/cnn_dann/config/base.yaml
+++ b/rul_adapt/construct/cnn_dann/config/base.yaml
@@ -9,6 +9,7 @@ dm:
   batch_size: 512
 
 feature_extractor:
+  _convert_: all  # needed for tensorboard hparam dumping
   _target_: rul_adapt.model.CnnExtractor
   input_channels: 14
   units: [10, 10, 10, 10, 1]
@@ -20,6 +21,7 @@ feature_extractor:
 regressor:
   _target_: rul_adapt.model.wrapper.DropoutPrefix
   wrapped:
+    _convert_: all
     _target_: rul_adapt.model.FullyConnectedHead
     input_channels: 30
     act_func_on_last_layer: False
@@ -28,6 +30,7 @@ regressor:
   dropout: 0.5
 
 domain_disc:
+  _convert_: all
   _target_: rul_adapt.model.FullyConnectedHead
   input_channels: 30
   act_func_on_last_layer: False
@@ -35,6 +38,7 @@ domain_disc:
   act_func: torch.nn.Tanh
 
 dann:
+  _convert_: all
   _target_: rul_adapt.approach.DannApproach
   dann_factor: 3.0
   lr: 0.001

--- a/rul_adapt/construct/consistency/config/base.yaml
+++ b/rul_adapt/construct/consistency/config/base.yaml
@@ -10,6 +10,7 @@ dm:
     batch_size: 128
 
 feature_extractor:
+  _convert_: all  # needed for tensorboard hparam dumping
   _target_: rul_adapt.model.CnnExtractor
   input_channels: ???
   units: [32, 16, 1]
@@ -19,12 +20,14 @@ feature_extractor:
   fc_dropout: 0.5
 
 regressor:
+  _convert_: all
   _target_: rul_adapt.model.FullyConnectedHead
   input_channels: ${feature_extractor.fc_units}
   act_func_on_last_layer: False
   units: [10, 1]
 
 domain_disc:
+  _convert_: all
   _target_: rul_adapt.model.FullyConnectedHead
   input_channels: ${feature_extractor.fc_units}
   act_func_on_last_layer: False

--- a/rul_adapt/construct/latent_align/config/base.yaml
+++ b/rul_adapt/construct/latent_align/config/base.yaml
@@ -13,6 +13,7 @@ dm:
     inductive: True
 
 feature_extractor:
+  _convert_: all  # needed for tensorboard hparam dumping
   _target_: rul_adapt.model.CnnExtractor
   input_channels: ???
   units: [32, 16, 1]
@@ -23,6 +24,7 @@ feature_extractor:
   fc_act_func: torch.nn.LeakyReLU
 
 regressor:
+  _convert_: all
   _target_: rul_adapt.model.FullyConnectedHead
   input_channels: ${feature_extractor.fc_units}
   act_func_on_last_layer: False

--- a/rul_adapt/construct/lstm_dann/config/base.yaml
+++ b/rul_adapt/construct/lstm_dann/config/base.yaml
@@ -9,6 +9,7 @@ dm:
   batch_size: ???
 
 feature_extractor:
+  _convert_: all  # needed for tensorboard hparam dumping
   _target_: rul_adapt.model.LstmExtractor
   input_channels: 24
   units: ???
@@ -17,6 +18,7 @@ feature_extractor:
   fc_dropout: ???
 
 regressor:
+  _convert_: all
   _target_: rul_adapt.model.FullyConnectedHead
   input_channels: ${feature_extractor.fc_units}
   act_func_on_last_layer: False
@@ -24,6 +26,7 @@ regressor:
   dropout: ???
 
 domain_disc:
+  _convert_: all
   _target_: rul_adapt.model.FullyConnectedHead
   input_channels: ${feature_extractor.fc_units}
   act_func_on_last_layer: False

--- a/rul_adapt/construct/tbigru/config/base.yaml
+++ b/rul_adapt/construct/tbigru/config/base.yaml
@@ -20,6 +20,7 @@ dm:
   window_size: 20
 
 feature_extractor:
+  _convert_: all  # needed for tensorboard hparam dumping
   _target_: rul_adapt.model.GruExtractor
   input_channels: 30
   fc_units: [15, 5]
@@ -27,12 +28,14 @@ feature_extractor:
   bidirectional: True
 
 regressor:
+  _convert_: all
   _target_: rul_adapt.model.FullyConnectedHead
   input_channels: 10
   act_func_on_last_layer: False
   units: [1]
 
 domain_disc:
+  _convert_: all
   _target_: rul_adapt.model.FullyConnectedHead
   input_channels: 10
   act_func_on_last_layer: False


### PR DESCRIPTION
When the default tensorboard logger tries to log a hparam of omegaconf container type, it fails. All included configs are modified so that omegaconf containers are converted to built-in ones.